### PR TITLE
The map syntax for calling a method was being used in a wrong way

### DIFF
--- a/grails-app/services/es/osoco/android/gcm/AndroidGcmService.groovy
+++ b/grails-app/services/es/osoco/android/gcm/AndroidGcmService.groovy
@@ -34,7 +34,7 @@ class AndroidGcmService {
 	 */
 	Result sendInstantMessage(Map data, String registrationId,
 			String apiKey = apiKeyFromConfig()) {
-		sendMessage(data: data, registrationIds: [registrationId], apiKey: apiKey)
+		sendMessage(data, [registrationId], '', apiKey)
 	}
 
 	/**
@@ -42,7 +42,7 @@ class AndroidGcmService {
 	 */
 	MulticastResult sendMulticastInstantMessage(Map data, List<String> registrationIds,
 			String apiKey = apiKeyFromConfig()) {
-		sendMessage(data:data, registrationIds: registrationIds, apiKey: apiKey)
+		sendMessage(data, registrationIds, '', apiKey)
 	}
 
 	/**


### PR DESCRIPTION
Some of the sendMessage methods wasn't working because they were being invoked using a map syntax that the method signature wasn't supporting. Updated the method calls so uses a classic syntax in method invokation.
